### PR TITLE
Adding support for Guzzle 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/**
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
         }
     ],
     "require": {
-        "guzzle/guzzle": "~3.7"
+        "guzzlehttp/guzzle": "~4.1.4",
+        "guzzlehttp/guzzle-services": "~0.3",
+        "guzzlehttp/oauth-subscriber": "0.1.x"
     },
     "autoload": {
         "psr-0": {

--- a/lib/Jcroll/FoursquareApiClient/Client/FoursquareClient.php
+++ b/lib/Jcroll/FoursquareApiClient/Client/FoursquareClient.php
@@ -5,7 +5,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Collection;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
-use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Event\ErrorEvent;
 use GuzzleHttp\Event\BeforeEvent;
 use \InvalidArgumentException;
 
@@ -19,12 +20,11 @@ class FoursquareClient extends GuzzleClient
             static::$serviceDescription = json_decode(file_get_contents(dirname(__DIR__).'/Resources/config/client.json'), true);
         }
 
-//        static::$serviceDescription['base_url'] = 'https://api.foursquare.com/v2/';
-
         $default = array(
             'verify' => true,
-            'event.before' => array(),
-            'event.after' => array()
+            'event.before' => function(BeforeEvent $e) { },
+            'event.after' => function(CompleteEvent $e) { },
+            'event.error' => function(ErrorEvent $e) { }
         );
 
         $required = array(
@@ -37,7 +37,6 @@ class FoursquareClient extends GuzzleClient
                 throw new InvalidArgumentException("Argument '{$value}' must not be blank.");
             }
         }
-
 
         $description = new Description(static::$serviceDescription);
 
@@ -62,12 +61,6 @@ class FoursquareClient extends GuzzleClient
 
         if (is_callable($config['event.error']))
             $httpClient->getEmitter()->on('error', $config['event.error']);
-
-//        $oauth = new Oauth1(array(
-//            'consumer_key' => $config['client_id'],
-//            'consumer_secret' => $config['client_secret']
-//        ));
-//         $httpClient->getEmitter()->attach($oauth);
 
         return new self($httpClient, $description);
     }

--- a/lib/Jcroll/FoursquareApiClient/Client/FoursquareClient.php
+++ b/lib/Jcroll/FoursquareApiClient/Client/FoursquareClient.php
@@ -6,21 +6,30 @@ use GuzzleHttp\Collection;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use GuzzleHttp\Event\BeforeEvent;
 use \InvalidArgumentException;
 
 class FoursquareClient extends GuzzleClient
 {
     static $serviceDescription = NULL;
+    private $httpClient = NULL;
     public static function factory($config = array())
     {
         if (static::$serviceDescription == NULL) {
             static::$serviceDescription = json_decode(file_get_contents(dirname(__DIR__).'/Resources/config/client.json'), true);
         }
 
-        $default = array('base_url' => 'https://api.foursquare.com/v2/');
+//        static::$serviceDescription['base_url'] = 'https://api.foursquare.com/v2/';
+
+        $default = array(
+            'verify' => true,
+            'event.before' => array(),
+            'event.after' => array()
+        );
+
         $required = array(
             'client_id',
-            'client_secret',
+            'client_secret'
         );
 
         foreach ($required as $value) {
@@ -29,24 +38,38 @@ class FoursquareClient extends GuzzleClient
             }
         }
 
+
         $description = new Description(static::$serviceDescription);
 
         $config = Collection::fromConfig($config, $default, $required);
-        $client = new Client(array(
-            'base_url' => $config->get('base_url'),
-            'query' => array(
-                'client_id' => $config['client_id'],
-                'client_secret' => $config['client_secret'],
-                'v' => '20130707'
-            ),
-            'defaults' => array('auth' => 'oauth')
+
+        $httpClient = new Client(array(
+            'defaults' => array(
+                'query' => array(
+                    'client_id' => $config['client_id'],
+                    'client_secret' => $config['client_secret'],
+                    'v' => '20130707'
+                ),
+                'verify' => $config['verify']
+            )
         ));
-        $oauth = new Oauth1(array(
-            'consumer_key' => $config['client_id'],
-            'consumer_secret' => $config['client_secret']
-        ));
-        $client->getEmitter()->attach($oauth);
-        return new self($client, $description);
+
+        if (is_callable($config['event.before']))
+            $httpClient->getEmitter()->on('before', $config['event.before']);
+
+        if (is_callable($config['event.complete']))
+            $httpClient->getEmitter()->on('complete', $config['event.complete']);
+
+        if (is_callable($config['event.error']))
+            $httpClient->getEmitter()->on('error', $config['event.error']);
+
+//        $oauth = new Oauth1(array(
+//            'consumer_key' => $config['client_id'],
+//            'consumer_secret' => $config['client_secret']
+//        ));
+//         $httpClient->getEmitter()->attach($oauth);
+
+        return new self($httpClient, $description);
     }
 
     public function addToken($token)

--- a/lib/Jcroll/FoursquareApiClient/Resources/config/client.json
+++ b/lib/Jcroll/FoursquareApiClient/Resources/config/client.json
@@ -1,4 +1,13 @@
 {
+    "baseUrl": "https://api.foursquare.com/v2/",
+    "models": {
+        "getResponse": {
+            "type": "object",
+            "additionalProperties": {
+                "location": "json"
+            }
+        }
+    },
     "operations": {
         "users": {
             "description": "Returns profile information for a given user, including selected badges and mayorships. The web profile for a user is visible at https://foursquare.com/user/USER_ID ",
@@ -10,6 +19,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}"
         },
         "users/leaderboard": {
@@ -21,11 +31,13 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/leaderboard"
         },
         "users/requests": {
             "description": "Shows a user the list of users with whom they have a pending friend request (i.e., someone tried to add the acting user as a friend, but the acting user has not accepted).",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "users/requests"
         },
         "users/search": {
@@ -57,11 +69,13 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/search"
         },
         "users/badges": {
             "description": "Returns badges for a given user.",
             "extends": "users",
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/badges"
         },
         "users/checkins": {
@@ -89,6 +103,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/checkins"
         },
         "users/friends": {
@@ -104,6 +119,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/friends"
         },
         "users/lists": {
@@ -119,11 +135,13 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/lists"
         },
         "users/mayorships": {
             "extends": "users",
             "description": "Returns a user's mayorships.",
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/mayorships"
         },
         "users/photos": {
@@ -139,6 +157,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/photos"
         },
         "users/tips": {
@@ -163,6 +182,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/tips"
         },
         "users/todos": {
@@ -178,6 +198,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/todos"
         },
         "users/venuehistory": {
@@ -197,24 +218,28 @@
                     "location": "query"
                 }
             },
+
             "uri": "users/{user_id}/venuehistory"
         },
         "users/approve": {
             "extends": "users",
             "description": "Approves a pending friend request from another user.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/approve"
         },
         "users/deny": {
             "extends": "users",
             "description": "Denies a pending friend request from another user.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/deny"
         },
         "users/request": {
             "extends": "users",
             "description": "Sends a friend request to another user. If the other user is a page then the requesting user will automatically start following the page.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/request"
         },
         "users/setpings": {
@@ -228,12 +253,14 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/setpings"
         },
         "users/unfriend": {
             "extends": "users",
             "description": "Cancels any relationship between the acting user and the specified user. ",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "users/{user_id}/unfriend"
         },
         "users/update": {
@@ -245,6 +272,7 @@
                     "location": "postField"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "users/self/update"
         },
         "venues": {
@@ -257,6 +285,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}"
         },
         "venues/add": {
@@ -322,11 +351,13 @@
                     "location": "postField"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/add"
         },
         "venues/categories": {
             "description": "Returns a hierarchical list of categories applied to venues.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/categories"
         },
         "venues/explore": {
@@ -398,6 +429,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/explore"
         },
         "venues/managed": {
@@ -413,6 +445,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/managed"
         },
         "venues/search": {
@@ -480,6 +513,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/search"
         },
         "venues/suggestcompletion": {
@@ -517,6 +551,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/suggestcompletion"
         },
         "venues/timeseries": {
@@ -541,6 +576,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/timeseries"
         },
         "venues/trending": {
@@ -561,12 +597,14 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/trending"
         },
         "venues/events": {
             "extends": "venues",
             "description": "Allows you to access information about the current events at a place. ",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/events"
         },
         "venues/herenow": {
@@ -583,24 +621,28 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/herenow"
         },
         "venues/hours": {
             "extends": "venues",
             "description": "Returns hours for a venue. ",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/hours"
         },
         "venues/likes": {
             "extends": "venues",
             "description": "Returns friends and a total count of users who have liked this venue.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/likes"
         },
         "venues/links": {
             "extends": "venues",
             "description": "Returns URLs or identifiers from third parties that have been applied to this venue, such as how the New York Times refers to this venue and a URL for additional information from nytimes.com. This is part of the foursquare Venue Map.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/links"
         },
         "venues/listed": {
@@ -621,18 +663,21 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/listed"
         },
         "venues/menu": {
             "extends": "venues",
             "description": "",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/menu"
         },
         "venues/nextvenues": {
             "extends": "venues",
             "description": "Returns menu information for a venue.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/nextvenues"
         },
         "venues/photos": {
@@ -653,12 +698,14 @@
                 }
             },
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/photos"
         },
         "venues/similar": {
             "extends": "venues",
             "description": "Returns a list of venues similar to the specified venue.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/similar"
         },
         "venues/stats": {
@@ -675,6 +722,7 @@
                 }
             },
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/stats"
         },
         "venues/tips": {
@@ -695,6 +743,7 @@
                 }
             },
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/tips"
         },
         "venues/dislike": {
@@ -708,6 +757,7 @@
                 }
             },
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/dislike"
         },
         "venues/edit": {
@@ -772,6 +822,7 @@
                 }
             },
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/edit"
         },
         "venues/flag": {
@@ -789,6 +840,7 @@
                 }
             },
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/flag"
         },
         "venues/like": {
@@ -803,6 +855,7 @@
                 }
             },
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/like"
         },
         "venues/proposeedit": {
@@ -851,6 +904,7 @@
                 }
             },
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/proposeedit"
         },
         "venues/setrole": {
@@ -873,6 +927,7 @@
                 }
             },
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venues/{venue_id}/setrole"
         },
         "venuegroups": {
@@ -885,6 +940,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}"
         },
         "venuegroups/add": {
@@ -901,17 +957,20 @@
                     "location": "postField"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/add"
         },
         "venuegroups/delete": {
             "extends": "venuegroups",
             "description": "Delete a venue group.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/delete"
         },
         "venuegroups/list": {
             "description": "List all venue groups owned by the user.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "venuegroups/list"
         },
         "venuegroups/timeseries": {
@@ -932,6 +991,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/timeseries"
         },
         "venuegroups/addvenue": {
@@ -945,11 +1005,13 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/addvenue"
         },
         "venuegroups/campaigns": {
             "extends": "venuegroups",
             "description": "Retrieve the campaigns that reference this venue group.",
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/campaigns"
         },
         "venuegroups/edit": {
@@ -994,6 +1056,7 @@
                     "location": "postField"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/edit"
         },
         "venuegroups/removevenue": {
@@ -1007,6 +1070,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/removevenue"
         },
         "venuegroups/update": {
@@ -1023,6 +1087,7 @@
                     "location": "postField"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "venuegroups/{group_id}/update"
         },
         "checkins": {
@@ -1039,6 +1104,7 @@
                     "location": "query"
                 }
             },
+            "responseModel": "getResponse",
             "uri": "checkins/{checkin_id}"
         },
         "checkins/add": {
@@ -1091,6 +1157,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "checkins/add"
         },
         "checkins/recent": {
@@ -1113,12 +1180,14 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "checkins/recent"
         },
         "checkins/likes": {
             "extends": "checkins",
             "description": "Returns friends and a total count of users who have liked this checkin.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "checkins/{checkin_id}/likes"
         },
         "checkins/addcomment": {
@@ -1137,6 +1206,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "checkins/{checkin_id}/addcomment"
         },
         "checkins/deletecomment": {
@@ -1150,6 +1220,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "checkins/{checkin_id}/deletecomment"
         },
         "checkins/like": {
@@ -1164,6 +1235,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "checkins/{checkin_id}/like"
         },
         "tips": {
@@ -1176,6 +1248,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}"
         },
         "tips/add": {
@@ -1203,6 +1276,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "tips/add"
         },
         "tips/search": {
@@ -1240,11 +1314,13 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "tips/search"
         },
         "tips/likes": {
             "extends": "tips",
             "description": "Returns friends and a total count of users who have liked this tip.",
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}/likes"
         },
         "tips/listed": {
@@ -1257,11 +1333,13 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}/listed"
         },
         "tips/saves": {
             "extends": "tips",
             "description": "Returns friends and a total count of users who have saved this tip.",
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}/saves"
         },
         "tips/flag": {
@@ -1280,6 +1358,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}/flag"
         },
         "tips/like": {
@@ -1294,12 +1373,14 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}/like"
         },
         "tips/unmark": {
             "extends": "tips",
             "description": "Allows you to remove a tip from your to-do list.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "tips/{tip_id}/unmark"
         },
         "lists": {
@@ -1337,6 +1418,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}"
         },
         "lists/add": {
@@ -1364,6 +1446,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/add"
         },
         "lists/followers": {
@@ -1376,6 +1459,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/followers"
         },
         "lists/saves": {
@@ -1388,6 +1472,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/saves"
         },
         "lists/suggestphoto": {
@@ -1401,18 +1486,21 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/suggestphoto"
         },
         "lists/suggesttip": {
             "extends": "lists/suggestphoto",
             "description": "Suggests tips that may be appropriate for this item",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/suggesttip"
         },
         "lists/suggestvenues": {
             "extends": "lists/saves",
             "description": "Suggests venues that may be appropriate for this list.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/suggestvenues"
         },
         "lists/additem": {
@@ -1451,6 +1539,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/additem"
         },
         "lists/deleteitem": {
@@ -1475,12 +1564,14 @@
                 }
 
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/deleteitem"
         },
         "lists/follow": {
             "extends": "lists/followers",
             "description": "Allows you to follow a list.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/follow"
         },
         "lists/moveitem": {
@@ -1504,6 +1595,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/moveitem"
         },
         "lists/share": {
@@ -1522,12 +1614,14 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/share"
         },
         "lists/unfollow": {
             "extends": "lists/followers",
             "description": "Allows you to unfollow a list.",
             "httpMethod": "POST",
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/unfollow"
         },
         "lists/update": {
@@ -1556,6 +1650,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/update"
         },
         "lists/updateitem": {
@@ -1589,6 +1684,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "lists/{list_id}/updateitem"
         },
         "updates": {
@@ -1600,6 +1696,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "updates/{update_id}"
         },
         "updates/notifications": {
@@ -1612,6 +1709,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "updates/notifications"
         },
         "updates/marknotificationsread": {
@@ -1624,6 +1722,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "updates/marknotificationsread"
         },
         "photos": {
@@ -1636,6 +1735,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "photos/{photo_id}"
         },
         "photos/add": {
@@ -1708,6 +1808,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "photos/add"
         },
         "settings": {
@@ -1720,11 +1821,13 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "settings/{setting_id}"
         },
         "settings/all": {
             "description": "Returns the settings of the acting user.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "settings/all"
         },
         "settings/set": {
@@ -1742,6 +1845,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "settings/{setting_id}/set"
         },
         "specials": {
@@ -1764,6 +1868,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/{special_id}"
         },
         "specials/add": {
@@ -1821,6 +1926,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/add"
         },
         "specials/list": {
@@ -1838,6 +1944,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/list"
         },
         "specials/search": {
@@ -1875,6 +1982,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/search"
         },
         "specials/configuration": {
@@ -1887,6 +1995,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/{special_id}/configuration"
         },
         "specials/flag": {
@@ -1914,6 +2023,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/{id}/flag"
         },
         "specials/retire": {
@@ -1926,6 +2036,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "specials/{special_id}/retire"
         },
         "campaigns": {
@@ -1938,6 +2049,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/{campaign_id}"
         },
         "campaigns/add": {
@@ -1975,6 +2087,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/add"
         },
         "campaigns/list": {
@@ -1997,6 +2110,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/list"
         },
         "campaigns/timeseries": {
@@ -2019,6 +2133,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/{campaign_id}/timeseries"
         },
         "campaigns/delete": {
@@ -2031,6 +2146,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/{campaign_id}/delete"
         },
         "campaigns/end": {
@@ -2043,6 +2159,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/{campaign_id}/end"
         },
         "campaigns/start": {
@@ -2060,6 +2177,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "campaigns/{campaign_id}/start"
         },
         "events": {
@@ -2072,11 +2190,13 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "events/{event_id}"
         },
         "events/categories": {
             "description": "Returns a hierarchical list of categories applied to events. ",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "events/categories"
         },
         "events/search": {
@@ -2099,6 +2219,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "events/search"
         },
         "events/add": {
@@ -2126,6 +2247,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "events/add"
         },
         "pages": {
@@ -2138,6 +2260,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pages/{user_id}"
         },
         "pages/add": {
@@ -2150,11 +2273,13 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pages/add"
         },
         "pages/managing": {
             "description": "Returns an array of the pages a user manages.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "pages/managing"
         },
         "pages/search": {
@@ -2177,6 +2302,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pages/search"
         },
         "pages/timeseries": {
@@ -2204,6 +2330,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pages/{page_id}/timeseries"
         },
         "pages/venues": {
@@ -2251,6 +2378,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pages/{page_id}/venues"
         },
         "pages/like": {
@@ -2269,6 +2397,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pages/{user_id}/like"
         },
         "pageupdates": {
@@ -2291,6 +2420,7 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pageupdates/{update_id}"
         },
         "pageupdates/add": {
@@ -2333,11 +2463,13 @@
                     "required": false
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pageupdates/add"
         },
         "pageupdates/list": {
             "description": "Returns a list of page updates created by the current user.",
             "httpMethod": "GET",
+            "responseModel": "getResponse",
             "uri": "pageupdates/list"
         },
         "pageupdates/delete": {
@@ -2350,6 +2482,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pageupdates/{update_id}/delete"
         },
         "pageupdates/like": {
@@ -2362,6 +2495,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "pageupdates/{update_id}/like"
         },
         "multi": {
@@ -2374,6 +2508,7 @@
                     "required": true
                 }
             },
+            "responseModel": "getResponse",
             "uri": "multi"
         },
         "multi/post": {

--- a/tests/Jcroll/FoursquareApiClient/Client/FoursquareClientTest.php
+++ b/tests/Jcroll/FoursquareApiClient/Client/FoursquareClientTest.php
@@ -22,12 +22,12 @@ class FoursquareClientTest extends \PHPUnit_Framework_TestCase
         $client = FoursquareClient::factory($config);
 
         $this->assertInstanceOf('\Jcroll\FoursquareApiClient\Client\FoursquareClient', $client);
-        $this->assertEquals($config['client_id'], $client->getDefaultOption('query')['client_id']);
-        $this->assertEquals($config['client_secret'], $client->getDefaultOption('query')['client_secret']);
+        $this->assertEquals($config['client_id'], $client->getHttpClient()->getDefaultOption('query')['client_id']);
+        $this->assertEquals($config['client_secret'], $client->getHttpClient()->getDefaultOption('query')['client_secret']);
     }
 
     /**
-     * @expectedException \Guzzle\Common\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testFactoryReturnsExceptionOnNullArguments()
     {
@@ -37,7 +37,7 @@ class FoursquareClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Guzzle\Common\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testFactoryReturnsExceptionOnBlankArguments()
     {
@@ -67,7 +67,7 @@ class FoursquareClientTest extends \PHPUnit_Framework_TestCase
         $client = FoursquareClient::factory($config);
         $client->addToken($token);
 
-        $this->assertEquals($token, $client->getDefaultOption('query')['oauth_token']);
+        $this->assertEquals($token, $client->getHttpClient()->getDefaultOption('query')['oauth_token']);
     }
 
     public function provideConfigValues()


### PR DESCRIPTION
Converted to Guzzle 4. All existing tests pass.

- Added support for the new Guzzel 4
- Added event config options for the Http Client (Before, Complete and Error)
- Added option to pass the `verify` option to fix issues with PHP 5.5.14+ on Mac OS X (homebrew)