### PR TITLE
add locale param to venues/categories

### DIFF
--- a/lib/Jcroll/FoursquareApiClient/Resources/config/client.json
+++ b/lib/Jcroll/FoursquareApiClient/Resources/config/client.json
@@ -327,7 +327,13 @@
         "venues/categories": {
             "description": "Returns a hierarchical list of categories applied to venues.",
             "httpMethod": "GET",
-            "uri": "venues/categories"
+            "uri": "venues/categories",
+            "parameters": {
+                "locale": {
+                    "description": "locale of response",
+                    "location": "query"
+                }
+            }
         },
         "venues/explore": {
             "description": "Returns a list of recommended venues near the current location. ",


### PR DESCRIPTION
Hello!
I tried to use this method with other locale but method has not any parameters, so may be if this little fix could change it. But I don't actually understand how to set locale by default.
Thank you!

P.S. https://developer.foursquare.com/overview/versioning
You can specify the locale by setting the Accept-Language HTTP header in your request. Alternatively, you can add a locale=XXX parameter to your request but HTTP header specification is preferred. We currently support en (default), es, fr, de, it, ja, th, tr, ko, ru, pt, and id.